### PR TITLE
Add order search feature with support for closed orders

### DIFF
--- a/buscar-pedido.html
+++ b/buscar-pedido.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <title>Buscar Pedido - Prisma</title>
+    <link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap' rel='stylesheet'>
+    <link rel="stylesheet" href="css/styles.css">
+    <link rel="stylesheet" href="css/buscar-pedido.css">
+</head>
+<body>
+    <div class="container-wide">
+        <a href="pedidos.html" class="back-link">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+            Volver a pedidos
+        </a>
+
+        <div class="page-header">
+            <div class="page-header-left">
+                <h1>Buscar Pedido</h1>
+                <p class="page-subtitle">Busca pedidos por nombre de cliente o número de orden (incluye pedidos cerrados)</p>
+            </div>
+        </div>
+
+        <!-- Search Box -->
+        <div class="search-container">
+            <div class="search-box">
+                <svg class="search-box-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+                <input type="text" class="search-input" id="search-input" placeholder="Nombre del cliente o número de orden..." autofocus>
+                <button class="search-btn" id="search-btn" onclick="performSearch()">
+                    Buscar
+                </button>
+            </div>
+            <p class="search-hint">Presiona Enter o haz clic en Buscar para buscar</p>
+        </div>
+
+        <!-- Search Results -->
+        <div class="search-results" id="search-results">
+            <!-- Initial state -->
+            <div class="search-empty-state" id="empty-state">
+                <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+                <h3>Busca un pedido</h3>
+                <p>Ingresa el nombre del cliente o el número de orden para buscar.</p>
+            </div>
+
+            <!-- Results list -->
+            <div class="results-list hidden" id="results-list">
+                <div class="results-header">
+                    <span class="results-count" id="results-count">0 resultados</span>
+                </div>
+                <div class="results-grid" id="results-grid">
+                    <!-- Result cards will be rendered here -->
+                </div>
+            </div>
+
+            <!-- No results state -->
+            <div class="search-empty-state hidden" id="no-results-state">
+                <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/></svg>
+                <h3>No se encontraron resultados</h3>
+                <p>No hay pedidos que coincidan con tu búsqueda. Intenta con otros términos.</p>
+            </div>
+        </div>
+
+        <!-- Order Detail Modal -->
+        <div class="modal-overlay" id="detail-modal">
+            <div class="modal modal-lg">
+                <div class="modal-header">
+                    <h2 class="modal-title" id="detail-modal-title">Detalles del Pedido</h2>
+                    <button class="modal-close" onclick="closeDetailModal()">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                    </button>
+                </div>
+                <div class="modal-body" id="detail-modal-body">
+                    <!-- Order details will be rendered here -->
+                </div>
+                <div class="modal-footer">
+                    <a href="#" class="btn btn-secondary btn-sm" id="notion-link" target="_blank">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                        Ver en Notion
+                    </a>
+                    <button class="btn btn-primary btn-sm" onclick="closeDetailModal()">Cerrar</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="footer">
+            Prisma · Buscar Pedido
+        </div>
+    </div>
+
+    <!-- Loading Overlay -->
+    <div class="loading-overlay" id="loading-overlay">
+        <div class="loading-card">
+            <div class="loading-spinner"></div>
+            <div class="loading-text" id="loading-text">Buscando...</div>
+        </div>
+    </div>
+
+    <!-- Scripts -->
+    <script src="js/config.js"></script>
+    <script src="js/utils.js"></script>
+    <script src="js/auth.js"></script>
+    <script src="js/mock-data.js"></script>
+    <script src="js/api.js"></script>
+    <script src="js/pages/buscar-pedido.js"></script>
+</body>
+</html>

--- a/css/buscar-pedido.css
+++ b/css/buscar-pedido.css
@@ -1,0 +1,467 @@
+/* ==========================================================================
+   Buscar Pedido Page Styles
+   ========================================================================== */
+
+/* Page Header */
+.page-header {
+    margin-bottom: 24px;
+}
+
+.page-header h1 {
+    font-size: 24px;
+    font-weight: 700;
+    margin-bottom: 4px;
+}
+
+.page-subtitle {
+    font-size: 14px;
+    color: var(--text-secondary);
+}
+
+/* ==========================================================================
+   Search Container
+   ========================================================================== */
+
+.search-container {
+    margin-bottom: 32px;
+}
+
+.search-box {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: var(--bg-primary);
+    border: 2px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 8px 8px 8px 16px;
+    transition: all 0.2s;
+    box-shadow: var(--shadow-sm);
+}
+
+.search-box:focus-within {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 4px var(--primary-light);
+}
+
+.search-box-icon {
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+
+.search-input {
+    flex: 1;
+    border: none;
+    background: transparent;
+    font-size: 16px;
+    font-family: inherit;
+    color: var(--text-primary);
+    padding: 8px 0;
+    outline: none;
+}
+
+.search-input::placeholder {
+    color: var(--text-muted);
+}
+
+.search-btn {
+    padding: 10px 24px;
+    background: var(--primary);
+    color: white;
+    border: none;
+    border-radius: var(--radius);
+    font-size: 14px;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.2s;
+    flex-shrink: 0;
+}
+
+.search-btn:hover {
+    background: var(--primary-hover);
+}
+
+.search-hint {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 8px;
+    text-align: center;
+}
+
+/* ==========================================================================
+   Search Results
+   ========================================================================== */
+
+.search-results {
+    min-height: 300px;
+}
+
+.search-empty-state {
+    text-align: center;
+    padding: 60px 20px;
+    color: var(--text-muted);
+}
+
+.search-empty-state svg {
+    margin-bottom: 16px;
+    opacity: 0.5;
+}
+
+.search-empty-state h3 {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+}
+
+.search-empty-state p {
+    font-size: 14px;
+}
+
+/* Results List */
+.results-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+}
+
+.results-count {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+
+.results-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 16px;
+}
+
+/* Result Card */
+.result-card {
+    background: var(--bg-primary);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-sm);
+    padding: 16px;
+    cursor: pointer;
+    transition: all 0.2s;
+    border: 1px solid var(--border);
+}
+
+.result-card:hover {
+    box-shadow: var(--shadow);
+    border-color: var(--primary);
+    transform: translateY(-2px);
+}
+
+.result-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 12px;
+}
+
+.result-card-cliente {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 2px;
+}
+
+.result-card-tipo {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+.result-card-body {
+    margin-bottom: 12px;
+}
+
+.result-card-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 6px 0;
+    font-size: 13px;
+    border-bottom: 1px solid var(--bg-tertiary);
+}
+
+.result-card-row:last-child {
+    border-bottom: none;
+}
+
+.result-card-label {
+    color: var(--text-muted);
+}
+
+.result-card-value {
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+.result-card-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
+}
+
+.result-card-date {
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+/* Status badges - reuse from pedidos.css */
+.order-status {
+    display: inline-block;
+    padding: 4px 10px;
+    font-size: 11px;
+    font-weight: 600;
+    border-radius: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    white-space: nowrap;
+}
+
+.order-status.pendiente_aprobacion,
+.order-status.pendiente_aprobación {
+    background: #fee2e2;
+    color: #dc2626;
+}
+
+.order-status.en_produccion,
+.order-status.en_producción {
+    background: #ffedd5;
+    color: #ea580c;
+}
+
+.order-status.listo_para_entrega,
+.order-status.listo_entrega {
+    background: #d1fae5;
+    color: #059669;
+}
+
+.order-status.entregado {
+    background: #dbeafe;
+    color: #2563eb;
+}
+
+.order-status.cancelado {
+    background: #f1f5f9;
+    color: #64748b;
+}
+
+/* Closed/Complete status */
+.order-status.cerrado_completo {
+    background: #e0e7ff;
+    color: #4338ca;
+}
+
+/* ==========================================================================
+   Detail Modal
+   ========================================================================== */
+
+.modal-lg {
+    max-width: 800px;
+}
+
+.modal-body {
+    max-height: 70vh;
+    overflow-y: auto;
+}
+
+/* Order Detail Sections */
+.detail-section {
+    margin-bottom: 24px;
+}
+
+.detail-section:last-child {
+    margin-bottom: 0;
+}
+
+.detail-section-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 12px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+}
+
+.detail-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+}
+
+.detail-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.detail-item.full-width {
+    grid-column: 1 / -1;
+}
+
+.detail-label {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.detail-value {
+    font-size: 14px;
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+.detail-value.highlight {
+    color: var(--primary);
+    font-weight: 600;
+}
+
+.detail-value.success {
+    color: var(--success);
+}
+
+.detail-value.warning {
+    color: var(--warning);
+}
+
+/* Order Header in Modal */
+.order-detail-header {
+    background: var(--bg-tertiary);
+    padding: 16px;
+    border-radius: var(--radius);
+    margin-bottom: 24px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.order-detail-header-left {
+    flex: 1;
+}
+
+.order-detail-title {
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin-bottom: 4px;
+}
+
+.order-detail-subtitle {
+    font-size: 14px;
+    color: var(--text-secondary);
+}
+
+/* Page Content Section */
+.page-content-section {
+    background: var(--bg-secondary);
+    border-radius: var(--radius);
+    padding: 16px;
+    margin-top: 16px;
+}
+
+.page-content-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.page-content-title svg {
+    color: var(--text-muted);
+}
+
+.page-content-blocks {
+    font-size: 14px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.page-content-block {
+    margin-bottom: 8px;
+}
+
+.page-content-block:last-child {
+    margin-bottom: 0;
+}
+
+.page-content-block.heading {
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-top: 16px;
+}
+
+.page-content-block.heading:first-child {
+    margin-top: 0;
+}
+
+.page-content-empty {
+    color: var(--text-muted);
+    font-style: italic;
+    text-align: center;
+    padding: 20px;
+}
+
+/* Saldo Display in Modal */
+.saldo-display-modal {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--primary);
+    text-align: center;
+    padding: 16px;
+    background: var(--primary-light);
+    border-radius: var(--radius);
+}
+
+/* ==========================================================================
+   Mobile Responsive
+   ========================================================================== */
+
+@media (max-width: 768px) {
+    .search-box {
+        flex-direction: column;
+        padding: 12px;
+    }
+
+    .search-box-icon {
+        display: none;
+    }
+
+    .search-input {
+        width: 100%;
+        text-align: center;
+    }
+
+    .search-btn {
+        width: 100%;
+    }
+
+    .results-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .detail-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .order-detail-header {
+        flex-direction: column;
+        gap: 12px;
+        text-align: center;
+    }
+
+    .modal-lg {
+        margin: 10px;
+    }
+}

--- a/css/pedidos.css
+++ b/css/pedidos.css
@@ -16,6 +16,12 @@
     margin-bottom: 4px;
 }
 
+.page-header-right {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
 .order-count {
     font-size: 14px;
     color: var(--text-secondary);

--- a/js/api.js
+++ b/js/api.js
@@ -174,6 +174,46 @@ const API = {
     },
 
     // ==========================================================================
+    // Order Search API
+    // ==========================================================================
+
+    /**
+     * Search orders by customer name or order number
+     * Includes orders with estado_final = "cerrado_completo"
+     * @param {string} query - Search query (customer name or order number)
+     * @returns {Promise<Object>} Search results with order data
+     */
+    async searchOrders(query) {
+        // Use mock data if enabled
+        if (USE_MOCK_DATA) {
+            return MockData.searchOrders(query);
+        }
+
+        const params = new URLSearchParams();
+        params.set('q', query);
+
+        return this.request('/orders/search?' + params.toString(), {
+            method: 'GET'
+        });
+    },
+
+    /**
+     * Get Notion page content (blocks/children) for an order
+     * @param {string} orderId - Notion page ID
+     * @returns {Promise<Object>} Page content with blocks array
+     */
+    async getOrderPageContent(orderId) {
+        // Use mock data if enabled
+        if (USE_MOCK_DATA) {
+            return MockData.getOrderPageContent(orderId);
+        }
+
+        return this.request(`/orders/${orderId}/content`, {
+            method: 'GET'
+        });
+    },
+
+    // ==========================================================================
     // Gold Movements API
     // ==========================================================================
 

--- a/js/mock-data.js
+++ b/js/mock-data.js
@@ -314,6 +314,73 @@ const MockData = {
             gemas_origen: 'tienda',
             gemas_listas: false,
             notas: 'CANCELADO - Cliente cambió de opinión. Anticipo devuelto.'
+        },
+        // Closed/Completed orders (estado_final = cerrado_completo) - for search testing
+        {
+            id: 'mock-closed-001',
+            numero_orden: 'ORD-2025-150',
+            nombre_cliente: 'María González Pérez',
+            telefono_cliente: '8181111222',
+            tipo_pedido: 'anillo_compromiso',
+            descripcion: 'Anillo de compromiso oro blanco 14k con diamante 0.3ct',
+            importe_total: 18500,
+            anticipo: 18500,
+            estado: 'Entregado',
+            estado_final: 'cerrado_completo',
+            fecha_pedido: '2025-11-15',
+            fecha_entrega_cliente: '2025-12-01',
+            fecha_entrega_tienda: '2025-11-28',
+            oro_gramos: 3.5,
+            oro_con_joyero: true,
+            joyero: 'Carlos',
+            gemas_requeridas: '1 diamante 0.3ct',
+            gemas_origen: 'tienda',
+            gemas_listas: true,
+            notas: 'Entregado exitosamente. Cliente muy satisfecho.'
+        },
+        {
+            id: 'mock-closed-002',
+            numero_orden: 'ORD-2025-145',
+            nombre_cliente: 'Roberto García Luna',
+            telefono_cliente: '8182223344',
+            tipo_pedido: 'argollas',
+            descripcion: 'Argollas de matrimonio oro amarillo 18k comfort fit',
+            importe_total: 24000,
+            anticipo: 24000,
+            estado: 'Entregado',
+            estado_final: 'cerrado_completo',
+            fecha_pedido: '2025-10-20',
+            fecha_entrega_cliente: '2025-11-15',
+            fecha_entrega_tienda: '2025-11-10',
+            oro_gramos: 12.8,
+            oro_con_joyero: true,
+            joyero: 'Victor',
+            gemas_requeridas: null,
+            gemas_origen: null,
+            gemas_listas: false,
+            notas: 'Grabado interior: R&L 15.11.2025'
+        },
+        {
+            id: 'mock-closed-003',
+            numero_orden: 'ORD-2025-130',
+            nombre_cliente: 'Ana María Rodríguez',
+            telefono_cliente: '8183334455',
+            tipo_pedido: 'collar',
+            descripcion: 'Collar con dije de corazón oro rosa 14k con zirconias',
+            importe_total: 5600,
+            anticipo: 5600,
+            estado: 'Entregado',
+            estado_final: 'cerrado_completo',
+            fecha_pedido: '2025-09-10',
+            fecha_entrega_cliente: '2025-09-25',
+            fecha_entrega_tienda: '2025-09-22',
+            oro_gramos: 4.2,
+            oro_con_joyero: true,
+            joyero: 'Carlos',
+            gemas_requeridas: '15 zirconias 1mm',
+            gemas_origen: 'tienda',
+            gemas_listas: true,
+            notas: 'Regalo de cumpleaños para hija.'
         }
     ],
 
@@ -705,6 +772,108 @@ const MockData = {
                     data: balances
                 });
             }, 200);
+        });
+    },
+
+    // ==========================================================================
+    // Order Search
+    // ==========================================================================
+
+    /**
+     * Search orders by customer name or order number (simulates API call)
+     * Includes orders with estado_final = "cerrado_completo"
+     * @param {string} query - Search query
+     * @returns {Object} Response with matching orders
+     */
+    searchOrders(query) {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                const searchQuery = query.toLowerCase().trim();
+
+                // Search across all orders including closed ones
+                const results = this.orders.filter(order => {
+                    const searchFields = [
+                        order.numero_orden,
+                        order.nombre_cliente,
+                        order.telefono_cliente,
+                        order.descripcion
+                    ].filter(Boolean).join(' ').toLowerCase();
+
+                    return searchFields.includes(searchQuery);
+                });
+
+                // Sort by date descending (most recent first)
+                results.sort((a, b) => {
+                    const dateA = new Date(a.fecha_pedido || '1970-01-01');
+                    const dateB = new Date(b.fecha_pedido || '1970-01-01');
+                    return dateB - dateA;
+                });
+
+                resolve({
+                    success: true,
+                    data: results
+                });
+            }, 400);
+        });
+    },
+
+    /**
+     * Get Notion page content for an order (simulates API call)
+     * @param {string} orderId - Order ID
+     * @returns {Object} Response with page content blocks
+     */
+    getOrderPageContent(orderId) {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                // Mock page content based on order ID
+                const mockContent = {
+                    'mock-001': {
+                        blocks: [
+                            { type: 'heading_2', text: 'Especificaciones del Diamante' },
+                            { type: 'paragraph', text: 'Diamante central: 0.5ct, corte brillante, color G, claridad VS1' },
+                            { type: 'paragraph', text: 'Diamantes laterales: 6 x 0.05ct, mismo corte y calidad' },
+                            { type: 'heading_2', text: 'Medidas' },
+                            { type: 'paragraph', text: 'Talla del anillo: 6.5' },
+                            { type: 'paragraph', text: 'Ancho de la banda: 2mm' },
+                            { type: 'heading_2', text: 'Notas de Producción' },
+                            { type: 'paragraph', text: 'Grabado solicitado: "M&J 2026" en el interior' },
+                            { type: 'paragraph', text: 'Cliente pidió caja especial de terciopelo azul.' }
+                        ]
+                    },
+                    'mock-closed-001': {
+                        blocks: [
+                            { type: 'heading_2', text: 'Historial del Pedido' },
+                            { type: 'paragraph', text: '15 Nov 2025 - Pedido recibido' },
+                            { type: 'paragraph', text: '18 Nov 2025 - Oro entregado a joyero' },
+                            { type: 'paragraph', text: '25 Nov 2025 - Anillo terminado' },
+                            { type: 'paragraph', text: '01 Dic 2025 - Entregado al cliente' },
+                            { type: 'heading_2', text: 'Feedback del Cliente' },
+                            { type: 'paragraph', text: 'El cliente quedó muy satisfecho con el resultado. Mencionó que la piedra brilla más de lo esperado.' }
+                        ]
+                    },
+                    'mock-closed-002': {
+                        blocks: [
+                            { type: 'heading_2', text: 'Detalles de las Argollas' },
+                            { type: 'paragraph', text: 'Argolla hombre: Talla 10, 6mm ancho' },
+                            { type: 'paragraph', text: 'Argolla mujer: Talla 6, 4mm ancho' },
+                            { type: 'paragraph', text: 'Acabado: Comfort fit, pulido brillante exterior, mate interior' },
+                            { type: 'heading_2', text: 'Grabado' },
+                            { type: 'paragraph', text: 'Interior de ambas: R&L 15.11.2025' }
+                        ]
+                    }
+                };
+
+                const content = mockContent[orderId] || {
+                    blocks: [
+                        { type: 'paragraph', text: 'No hay notas adicionales para este pedido.' }
+                    ]
+                };
+
+                resolve({
+                    success: true,
+                    data: content
+                });
+            }, 300);
         });
     },
 

--- a/js/pages/buscar-pedido.js
+++ b/js/pages/buscar-pedido.js
@@ -1,0 +1,472 @@
+/**
+ * Buscar Pedido Page
+ *
+ * Search functionality for orders including closed/completed ones.
+ * Displays full order details including Notion page content.
+ */
+
+// State
+let searchResults = [];
+let currentOrder = null;
+
+/**
+ * Initialize page
+ */
+function initPage() {
+    // Check authentication
+    if (!Auth.isAuthenticated()) {
+        if (USE_MOCK_DATA) {
+            sessionStorage.setItem('prisma_user', JSON.stringify({
+                id: 'dev',
+                name: 'Developer',
+                isAdmin: true
+            }));
+        } else {
+            window.location.href = 'index.html';
+            return;
+        }
+    }
+
+    // Set up search input event listener
+    const searchInput = document.getElementById('search-input');
+    if (searchInput) {
+        searchInput.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') {
+                performSearch();
+            }
+        });
+    }
+}
+
+/**
+ * Perform search
+ */
+async function performSearch() {
+    const searchInput = document.getElementById('search-input');
+    const query = searchInput.value.trim();
+
+    if (!query) {
+        Utils.showToast('Ingresa un término de búsqueda', 'warning');
+        searchInput.focus();
+        return;
+    }
+
+    if (query.length < 2) {
+        Utils.showToast('Ingresa al menos 2 caracteres', 'warning');
+        searchInput.focus();
+        return;
+    }
+
+    showLoading('Buscando pedidos...');
+
+    try {
+        const response = await API.searchOrders(query);
+
+        if (response.success) {
+            searchResults = response.data || [];
+            renderResults();
+        } else {
+            Utils.showToast(response.error || 'Error al buscar', 'error');
+            showNoResults();
+        }
+    } catch (error) {
+        console.error('Error searching orders:', error);
+        Utils.showToast('Error de conexión', 'error');
+        showNoResults();
+    } finally {
+        hideLoading();
+    }
+}
+
+/**
+ * Render search results
+ */
+function renderResults() {
+    const emptyState = document.getElementById('empty-state');
+    const resultsList = document.getElementById('results-list');
+    const noResultsState = document.getElementById('no-results-state');
+    const resultsGrid = document.getElementById('results-grid');
+    const resultsCount = document.getElementById('results-count');
+
+    // Hide all states first
+    emptyState.classList.add('hidden');
+    resultsList.classList.add('hidden');
+    noResultsState.classList.add('hidden');
+
+    if (searchResults.length === 0) {
+        noResultsState.classList.remove('hidden');
+        return;
+    }
+
+    // Show results
+    resultsList.classList.remove('hidden');
+    resultsCount.textContent = `${searchResults.length} resultado${searchResults.length !== 1 ? 's' : ''}`;
+
+    // Render cards
+    resultsGrid.innerHTML = searchResults.map(order => renderResultCard(order)).join('');
+}
+
+/**
+ * Render a result card
+ * @param {Object} order - Order data
+ * @returns {string} HTML string
+ */
+function renderResultCard(order) {
+    const saldo = (order.importe_total || 0) - (order.anticipo || 0);
+    const statusClass = getStatusClass(order.estado, order.estado_final);
+    const statusDisplay = order.estado_final === 'cerrado_completo' ? 'Cerrado' : (order.estado || 'Sin estado');
+
+    return `
+        <div class="result-card" onclick="openOrderDetail('${order.id}')">
+            <div class="result-card-header">
+                <div>
+                    <div class="result-card-cliente">[${escapeHtml(order.numero_orden || 'Sin número')}] ${escapeHtml(order.nombre_cliente || 'Sin nombre')}</div>
+                    <div class="result-card-tipo">${Utils.getTipoPedidoName(order.tipo_pedido) || order.tipo_pedido || 'Sin tipo'}</div>
+                </div>
+                <span class="order-status ${statusClass}">${statusDisplay}</span>
+            </div>
+            <div class="result-card-body">
+                <div class="result-card-row">
+                    <span class="result-card-label">Total</span>
+                    <span class="result-card-value">${Utils.formatCurrency(order.importe_total)}</span>
+                </div>
+                <div class="result-card-row">
+                    <span class="result-card-label">Saldo</span>
+                    <span class="result-card-value" style="color: ${saldo > 0 ? 'var(--primary)' : 'var(--success)'};">${Utils.formatCurrency(saldo)}</span>
+                </div>
+                ${order.joyero ? `
+                <div class="result-card-row">
+                    <span class="result-card-label">Joyero</span>
+                    <span class="result-card-value">${escapeHtml(order.joyero)}</span>
+                </div>
+                ` : ''}
+            </div>
+            <div class="result-card-footer">
+                <span class="result-card-date">
+                    ${order.fecha_entrega_cliente ? `Entrega: ${Utils.formatDate(order.fecha_entrega_cliente)}` : 'Sin fecha de entrega'}
+                </span>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Get status CSS class
+ * @param {string} estado - Current status
+ * @param {string} estadoFinal - Final status (if closed)
+ * @returns {string} CSS class
+ */
+function getStatusClass(estado, estadoFinal) {
+    if (estadoFinal === 'cerrado_completo') {
+        return 'cerrado_completo';
+    }
+
+    if (!estado) return '';
+
+    const statusMap = {
+        'Pendiente Aprobación': 'pendiente_aprobacion',
+        'En Producción': 'en_produccion',
+        'Listo para Entrega': 'listo_para_entrega',
+        'Listo Entrega': 'listo_entrega',
+        'Entregado': 'entregado',
+        'Cancelado': 'cancelado'
+    };
+
+    return statusMap[estado] || estado.toLowerCase().replace(/\s+/g, '_').replace(/[áéíóú]/g, match => {
+        const map = { 'á': 'a', 'é': 'e', 'í': 'i', 'ó': 'o', 'ú': 'u' };
+        return map[match];
+    });
+}
+
+/**
+ * Open order detail modal
+ * @param {string} orderId - Order ID
+ */
+async function openOrderDetail(orderId) {
+    const order = searchResults.find(o => o.id === orderId);
+    if (!order) {
+        Utils.showToast('Pedido no encontrado', 'error');
+        return;
+    }
+
+    currentOrder = order;
+    showLoading('Cargando detalles...');
+
+    try {
+        // Fetch page content from Notion
+        const contentResponse = await API.getOrderPageContent(orderId);
+        const pageContent = contentResponse.success ? contentResponse.data : null;
+
+        renderOrderDetail(order, pageContent);
+        openDetailModal();
+    } catch (error) {
+        console.error('Error fetching page content:', error);
+        // Still show the order details even if content fetch fails
+        renderOrderDetail(order, null);
+        openDetailModal();
+    } finally {
+        hideLoading();
+    }
+}
+
+/**
+ * Render order detail in modal
+ * @param {Object} order - Order data
+ * @param {Object} pageContent - Notion page content (blocks)
+ */
+function renderOrderDetail(order, pageContent) {
+    const modalTitle = document.getElementById('detail-modal-title');
+    const modalBody = document.getElementById('detail-modal-body');
+    const notionLink = document.getElementById('notion-link');
+
+    const saldo = (order.importe_total || 0) - (order.anticipo || 0);
+    const statusClass = getStatusClass(order.estado, order.estado_final);
+    const statusDisplay = order.estado_final === 'cerrado_completo' ? 'Cerrado Completo' : (order.estado || 'Sin estado');
+
+    modalTitle.textContent = `Pedido ${order.numero_orden || 'Sin número'}`;
+    notionLink.href = `https://www.notion.so/eduardoflores/${order.id.replace(/-/g, '')}`;
+
+    const html = `
+        <!-- Order Header -->
+        <div class="order-detail-header">
+            <div class="order-detail-header-left">
+                <div class="order-detail-title">${escapeHtml(order.nombre_cliente || 'Sin nombre')}</div>
+                <div class="order-detail-subtitle">${Utils.getTipoPedidoName(order.tipo_pedido) || order.tipo_pedido || 'Sin tipo'}</div>
+            </div>
+            <span class="order-status ${statusClass}">${statusDisplay}</span>
+        </div>
+
+        <!-- Customer Information -->
+        <div class="detail-section">
+            <div class="detail-section-title">Información del Cliente</div>
+            <div class="detail-grid">
+                <div class="detail-item">
+                    <span class="detail-label">Nombre</span>
+                    <span class="detail-value">${escapeHtml(order.nombre_cliente || '-')}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Teléfono</span>
+                    <span class="detail-value">${escapeHtml(order.telefono_cliente || '-')}</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Order Details -->
+        <div class="detail-section">
+            <div class="detail-section-title">Detalles del Pedido</div>
+            <div class="detail-grid">
+                <div class="detail-item">
+                    <span class="detail-label">Número de Orden</span>
+                    <span class="detail-value">${escapeHtml(order.numero_orden || '-')}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Tipo de Pedido</span>
+                    <span class="detail-value">${Utils.getTipoPedidoName(order.tipo_pedido) || order.tipo_pedido || '-'}</span>
+                </div>
+                <div class="detail-item full-width">
+                    <span class="detail-label">Descripción</span>
+                    <span class="detail-value">${escapeHtml(order.descripcion || '-')}</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Financial Information -->
+        <div class="detail-section">
+            <div class="detail-section-title">Información Financiera</div>
+            <div class="detail-grid">
+                <div class="detail-item">
+                    <span class="detail-label">Importe Total</span>
+                    <span class="detail-value">${Utils.formatCurrency(order.importe_total)}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Anticipo</span>
+                    <span class="detail-value success">${Utils.formatCurrency(order.anticipo)}</span>
+                </div>
+            </div>
+            <div class="saldo-display-modal" style="margin-top: 16px;">
+                Saldo: ${Utils.formatCurrency(saldo)}
+            </div>
+        </div>
+
+        <!-- Production Information -->
+        <div class="detail-section">
+            <div class="detail-section-title">Producción</div>
+            <div class="detail-grid">
+                <div class="detail-item">
+                    <span class="detail-label">Joyero</span>
+                    <span class="detail-value">${escapeHtml(order.joyero || 'Sin asignar')}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Oro (gramos)</span>
+                    <span class="detail-value">${order.oro_gramos ? order.oro_gramos + 'g' : '-'}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Oro con Joyero</span>
+                    <span class="detail-value ${order.oro_con_joyero ? 'success' : ''}">${order.oro_con_joyero ? 'Sí' : 'No'}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Gemas Listas</span>
+                    <span class="detail-value ${order.gemas_listas ? 'success' : ''}">${order.gemas_listas ? 'Sí' : 'No'}</span>
+                </div>
+                ${order.gemas_requeridas ? `
+                <div class="detail-item full-width">
+                    <span class="detail-label">Gemas Requeridas</span>
+                    <span class="detail-value">${escapeHtml(order.gemas_requeridas)}</span>
+                </div>
+                ` : ''}
+                ${order.gemas_origen ? `
+                <div class="detail-item">
+                    <span class="detail-label">Origen de Gemas</span>
+                    <span class="detail-value">${escapeHtml(order.gemas_origen)}</span>
+                </div>
+                ` : ''}
+            </div>
+        </div>
+
+        <!-- Dates -->
+        <div class="detail-section">
+            <div class="detail-section-title">Fechas</div>
+            <div class="detail-grid">
+                <div class="detail-item">
+                    <span class="detail-label">Fecha de Pedido</span>
+                    <span class="detail-value">${Utils.formatDate(order.fecha_pedido)}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Entrega Cliente</span>
+                    <span class="detail-value">${Utils.formatDate(order.fecha_entrega_cliente)}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Entrega Tienda</span>
+                    <span class="detail-value">${Utils.formatDate(order.fecha_entrega_tienda)}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Fecha Fabricación</span>
+                    <span class="detail-value">${Utils.formatDate(order.fecha_fabricacion)}</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Notes -->
+        ${order.notas ? `
+        <div class="detail-section">
+            <div class="detail-section-title">Notas</div>
+            <div class="detail-value">${escapeHtml(order.notas)}</div>
+        </div>
+        ` : ''}
+
+        <!-- Page Content -->
+        <div class="detail-section">
+            <div class="detail-section-title">Contenido de la Página</div>
+            <div class="page-content-section">
+                <div class="page-content-title">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>
+                    Notas de Notion
+                </div>
+                <div class="page-content-blocks">
+                    ${renderPageContent(pageContent)}
+                </div>
+            </div>
+        </div>
+    `;
+
+    modalBody.innerHTML = html;
+}
+
+/**
+ * Render Notion page content blocks
+ * @param {Object} pageContent - Page content data
+ * @returns {string} HTML string
+ */
+function renderPageContent(pageContent) {
+    if (!pageContent || !pageContent.blocks || pageContent.blocks.length === 0) {
+        return '<div class="page-content-empty">No hay contenido adicional en esta página.</div>';
+    }
+
+    return pageContent.blocks.map(block => {
+        const blockClass = block.type === 'heading_1' || block.type === 'heading_2' || block.type === 'heading_3'
+            ? 'page-content-block heading'
+            : 'page-content-block';
+
+        return `<div class="${blockClass}">${escapeHtml(block.text || '')}</div>`;
+    }).join('');
+}
+
+/**
+ * Show no results state
+ */
+function showNoResults() {
+    const emptyState = document.getElementById('empty-state');
+    const resultsList = document.getElementById('results-list');
+    const noResultsState = document.getElementById('no-results-state');
+
+    emptyState.classList.add('hidden');
+    resultsList.classList.add('hidden');
+    noResultsState.classList.remove('hidden');
+}
+
+/**
+ * Open detail modal
+ */
+function openDetailModal() {
+    const modal = document.getElementById('detail-modal');
+    modal.classList.add('active');
+    document.body.style.overflow = 'hidden';
+}
+
+/**
+ * Close detail modal
+ */
+function closeDetailModal() {
+    const modal = document.getElementById('detail-modal');
+    modal.classList.remove('active');
+    document.body.style.overflow = '';
+    currentOrder = null;
+}
+
+/**
+ * Show loading overlay
+ * @param {string} message - Loading message
+ */
+function showLoading(message = 'Cargando...') {
+    const overlay = document.getElementById('loading-overlay');
+    const text = document.getElementById('loading-text');
+    if (text) text.textContent = message;
+    if (overlay) overlay.classList.add('active');
+}
+
+/**
+ * Hide loading overlay
+ */
+function hideLoading() {
+    const overlay = document.getElementById('loading-overlay');
+    if (overlay) overlay.classList.remove('active');
+}
+
+/**
+ * Escape HTML to prevent XSS
+ * @param {string} str - String to escape
+ * @returns {string} Escaped string
+ */
+function escapeHtml(str) {
+    if (!str) return '';
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+}
+
+// Close modal on backdrop click
+document.addEventListener('click', (e) => {
+    if (e.target.classList.contains('modal-overlay')) {
+        closeDetailModal();
+    }
+});
+
+// Close modal on Escape key
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+        closeDetailModal();
+    }
+});
+
+// Initialize on page load
+document.addEventListener('DOMContentLoaded', initPage);

--- a/pedidos.html
+++ b/pedidos.html
@@ -21,6 +21,10 @@
                 <p class="order-count" id="order-count">Cargando...</p>
             </div>
             <div class="page-header-right">
+                <a href="buscar-pedido.html" class="btn btn-secondary btn-sm">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+                    Buscar
+                </a>
                 <a href="nuevo-pedido.html" class="btn btn-primary btn-sm">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
                     Nuevo


### PR DESCRIPTION
- Create dedicated search page (buscar-pedido.html) accessible from orders page
- Search by customer name or order number including cerrado_completo orders
- Display full order details with Notion page content (blocks/children)
- Add searchOrders and getOrderPageContent API methods
- Include mock data for testing with closed order examples

https://claude.ai/code/session_011RSW5xJqJCZNh9rAicYSDU