### PR TITLE
Fix broken modal UI in search results page

### DIFF
--- a/css/buscar-pedido.css
+++ b/css/buscar-pedido.css
@@ -261,7 +261,87 @@
 }
 
 /* ==========================================================================
-   Detail Modal
+   Modal Base Styles
+   ========================================================================== */
+
+.modal-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1000;
+    backdrop-filter: blur(4px);
+    overflow-y: auto;
+    padding: 20px;
+}
+
+.modal-overlay.active {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+}
+
+.modal {
+    background: var(--bg-primary);
+    border-radius: var(--radius-lg);
+    width: 100%;
+    max-width: 600px;
+    margin: 40px 0;
+    box-shadow: var(--shadow-lg);
+    animation: modalSlideIn 0.3s ease;
+}
+
+@keyframes modalSlideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 24px;
+    border-bottom: 1px solid var(--border);
+}
+
+.modal-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.modal-close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-muted);
+    padding: 4px;
+    transition: color 0.2s;
+}
+
+.modal-close:hover {
+    color: var(--text-primary);
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 16px 24px;
+    border-top: 1px solid var(--border);
+}
+
+/* ==========================================================================
+   Detail Modal (Size Override)
    ========================================================================== */
 
 .modal-lg {
@@ -461,7 +541,15 @@
         text-align: center;
     }
 
+    .modal {
+        margin: 20px 0;
+    }
+
     .modal-lg {
-        margin: 10px;
+        margin: 10px 0;
+    }
+
+    .modal-overlay {
+        padding: 10px;
     }
 }


### PR DESCRIPTION
The order detail modal was missing base modal styles (modal-overlay, modal container, modal-header, modal-close, modal-footer) because buscar-pedido.css didn't include these styles that were only defined in pedidos.css. This caused the modal to display inline with a big X button and no scrolling, rather than as a proper overlay modal.

Fixes #7