### PR TITLE
Fix modal content misalignment and text overflow

### DIFF
--- a/css/buscar-pedido.css
+++ b/css/buscar-pedido.css
@@ -292,6 +292,7 @@
     margin: 40px 0;
     box-shadow: var(--shadow-lg);
     animation: modalSlideIn 0.3s ease;
+    overflow: hidden;
 }
 
 @keyframes modalSlideIn {
@@ -349,6 +350,7 @@
 }
 
 .modal-body {
+    padding: 24px;
     max-height: 70vh;
     overflow-y: auto;
 }
@@ -398,6 +400,8 @@
     font-size: 14px;
     color: var(--text-primary);
     font-weight: 500;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
 }
 
 .detail-value.highlight {
@@ -466,6 +470,8 @@
     font-size: 14px;
     color: var(--text-secondary);
     line-height: 1.6;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
 }
 
 .page-content-block {


### PR DESCRIPTION
## Summary
- Add missing padding to modal-body (24px) to give content proper spacing from modal edges
- Add word-wrap/overflow-wrap to detail-value and page-content-blocks to prevent long text from overflowing horizontally
- Add overflow: hidden to modal container to prevent content bleeding

## Test plan
- [ ] Navigate to the "Buscar Pedido" (search) page
- [ ] Search for an order and click on a result to open the modal
- [ ] Verify modal content has proper padding and is not flush against edges
- [ ] Verify long text wraps properly and does not overflow horizontally
- [ ] Verify all content is visible and scrollable within the modal
- [ ] Test on mobile screen sizes

Fixes #9
