### PR TITLE
Fix Notion page child content not displaying in search results

### DIFF
--- a/css/buscar-pedido.css
+++ b/css/buscar-pedido.css
@@ -499,6 +499,141 @@
     padding: 20px;
 }
 
+/* Child Page Block */
+.page-content-block.child-page {
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 10px 12px;
+    margin: 8px 0;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.page-content-block.child-page::before {
+    content: "\1F4C4 ";
+}
+
+/* Child Database Block */
+.page-content-block.child-database {
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 10px 12px;
+    margin: 8px 0;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.page-content-block.child-database::before {
+    content: "\1F4CA ";
+}
+
+/* List Items */
+.page-content-block.list-item {
+    padding-left: 20px;
+    position: relative;
+}
+
+.page-content-block.list-item.bulleted::before {
+    content: "\2022";
+    position: absolute;
+    left: 6px;
+    color: var(--text-muted);
+}
+
+.page-content-block.list-item.numbered {
+    counter-increment: list-counter;
+}
+
+/* To-Do Items */
+.page-content-block.to-do {
+    padding-left: 24px;
+    position: relative;
+}
+
+.page-content-block.to-do::before {
+    content: "\2610";
+    position: absolute;
+    left: 4px;
+    font-size: 16px;
+}
+
+.page-content-block.to-do.checked::before {
+    content: "\2611";
+    color: var(--success);
+}
+
+.page-content-block.to-do.checked {
+    text-decoration: line-through;
+    color: var(--text-muted);
+}
+
+/* Toggle Block */
+.page-content-block.toggle {
+    padding-left: 20px;
+    position: relative;
+}
+
+.page-content-block.toggle::before {
+    content: "\25B6";
+    position: absolute;
+    left: 4px;
+    font-size: 10px;
+    color: var(--text-muted);
+}
+
+/* Callout Block */
+.page-content-block.callout {
+    background: var(--bg-primary);
+    border-left: 3px solid var(--primary);
+    padding: 12px 16px;
+    margin: 8px 0;
+    border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+/* Quote Block */
+.page-content-block.quote {
+    border-left: 3px solid var(--text-muted);
+    padding-left: 16px;
+    font-style: italic;
+    margin: 8px 0;
+}
+
+/* Code Block */
+.page-content-block.code {
+    background: var(--bg-tertiary);
+    padding: 12px 16px;
+    border-radius: var(--radius);
+    font-family: monospace;
+    font-size: 13px;
+    margin: 8px 0;
+    white-space: pre-wrap;
+    overflow-x: auto;
+}
+
+/* Divider Block */
+.page-content-block.divider {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 16px 0;
+    height: 1px;
+    font-size: 0;
+}
+
+/* Indentation for nested blocks */
+.page-content-block.indent-1 {
+    margin-left: 24px;
+}
+
+.page-content-block.indent-2 {
+    margin-left: 48px;
+}
+
+.page-content-block.indent-3 {
+    margin-left: 72px;
+}
+
 /* Saldo Display in Modal */
 .saldo-display-modal {
     font-size: 24px;

--- a/js/pages/buscar-pedido.js
+++ b/js/pages/buscar-pedido.js
@@ -373,6 +373,125 @@ function renderOrderDetail(order, pageContent) {
 }
 
 /**
+ * Extract text content from a Notion block
+ * Handles both simplified format (block.text) and native Notion API format
+ * @param {Object} block - Notion block object
+ * @returns {string} Plain text content
+ */
+function extractBlockText(block) {
+    // Handle simplified mock format (block.text)
+    if (block.text !== undefined) {
+        return block.text;
+    }
+
+    const blockType = block.type;
+
+    // Handle child_page blocks - extract title
+    if (blockType === 'child_page' && block.child_page) {
+        return block.child_page.title || '';
+    }
+
+    // Handle child_database blocks
+    if (blockType === 'child_database' && block.child_database) {
+        return block.child_database.title || '';
+    }
+
+    // Handle blocks with rich_text content (paragraph, headings, list items, etc.)
+    const blockContent = block[blockType];
+    if (blockContent && blockContent.rich_text && Array.isArray(blockContent.rich_text)) {
+        return blockContent.rich_text.map(rt => rt.plain_text || rt.text?.content || '').join('');
+    }
+
+    // Handle toggle blocks (may have title in rich_text)
+    if (blockType === 'toggle' && blockContent) {
+        const toggleText = blockContent.rich_text?.map(rt => rt.plain_text || '').join('') || '';
+        return toggleText;
+    }
+
+    // Handle callout blocks
+    if (blockType === 'callout' && blockContent) {
+        const calloutText = blockContent.rich_text?.map(rt => rt.plain_text || '').join('') || '';
+        return calloutText;
+    }
+
+    // Handle quote blocks
+    if (blockType === 'quote' && blockContent) {
+        const quoteText = blockContent.rich_text?.map(rt => rt.plain_text || '').join('') || '';
+        return quoteText;
+    }
+
+    // Handle code blocks
+    if (blockType === 'code' && blockContent) {
+        const codeText = blockContent.rich_text?.map(rt => rt.plain_text || '').join('') || '';
+        return codeText;
+    }
+
+    // Handle divider (return empty or visual separator indicator)
+    if (blockType === 'divider') {
+        return '---';
+    }
+
+    return '';
+}
+
+/**
+ * Render a single Notion block as HTML
+ * @param {Object} block - Notion block object
+ * @param {number} depth - Nesting depth for indentation
+ * @returns {string} HTML string
+ */
+function renderBlock(block, depth = 0) {
+    const blockType = block.type;
+    const text = extractBlockText(block);
+    const indentClass = depth > 0 ? ` indent-${Math.min(depth, 3)}` : '';
+
+    // Determine CSS class based on block type
+    let blockClass = 'page-content-block';
+    if (blockType === 'heading_1' || blockType === 'heading_2' || blockType === 'heading_3') {
+        blockClass += ' heading';
+    } else if (blockType === 'child_page') {
+        blockClass += ' child-page';
+    } else if (blockType === 'child_database') {
+        blockClass += ' child-database';
+    } else if (blockType === 'bulleted_list_item') {
+        blockClass += ' list-item bulleted';
+    } else if (blockType === 'numbered_list_item') {
+        blockClass += ' list-item numbered';
+    } else if (blockType === 'to_do') {
+        const isChecked = block.to_do?.checked || false;
+        blockClass += ` to-do${isChecked ? ' checked' : ''}`;
+    } else if (blockType === 'toggle') {
+        blockClass += ' toggle';
+    } else if (blockType === 'callout') {
+        blockClass += ' callout';
+    } else if (blockType === 'quote') {
+        blockClass += ' quote';
+    } else if (blockType === 'code') {
+        blockClass += ' code';
+    } else if (blockType === 'divider') {
+        blockClass += ' divider';
+    }
+
+    blockClass += indentClass;
+
+    // Skip empty blocks except dividers
+    if (!text && blockType !== 'divider') {
+        return '';
+    }
+
+    // Render the block
+    let html = `<div class="${blockClass}">${escapeHtml(text)}</div>`;
+
+    // Recursively render children if present
+    if (block.children && Array.isArray(block.children) && block.children.length > 0) {
+        const childrenHtml = block.children.map(child => renderBlock(child, depth + 1)).join('');
+        html += childrenHtml;
+    }
+
+    return html;
+}
+
+/**
  * Render Notion page content blocks
  * @param {Object} pageContent - Page content data
  * @returns {string} HTML string
@@ -382,13 +501,7 @@ function renderPageContent(pageContent) {
         return '<div class="page-content-empty">No hay contenido adicional en esta página.</div>';
     }
 
-    return pageContent.blocks.map(block => {
-        const blockClass = block.type === 'heading_1' || block.type === 'heading_2' || block.type === 'heading_3'
-            ? 'page-content-block heading'
-            : 'page-content-block';
-
-        return `<div class="${blockClass}">${escapeHtml(block.text || '')}</div>`;
-    }).join('');
+    return pageContent.blocks.map(block => renderBlock(block, 0)).filter(html => html).join('');
 }
 
 /**


### PR DESCRIPTION
The renderPageContent function expected a simplified block format with
block.text, but the Notion API returns blocks in a nested structure
where text content is in block[type].rich_text[].plain_text.

Changes:
- Add extractBlockText() to handle both mock and native Notion formats
- Add renderBlock() to properly render different block types with styling
- Support child_page, child_database, lists, todos, toggles, callouts,
  quotes, code blocks, and dividers
- Add CSS styles for all new block types with proper visual formatting
- Support nested blocks with indentation

Fixes #11