### PR TITLE
Fix API response handling for Notion page content

### DIFF
--- a/js/pages/buscar-pedido.js
+++ b/js/pages/buscar-pedido.js
@@ -195,7 +195,19 @@ async function openOrderDetail(orderId) {
     try {
         // Fetch page content from Notion
         const contentResponse = await API.getOrderPageContent(orderId);
-        const pageContent = contentResponse.success ? contentResponse.data : null;
+
+        // Handle different API response formats:
+        // - Standard format: { success: true, data: { blocks/results: [...] } }
+        // - Direct data format: { blocks/results: [...] }
+        // - Direct array format: [...]
+        let pageContent = null;
+        if (contentResponse) {
+            if (contentResponse.success && contentResponse.data) {
+                pageContent = contentResponse.data;
+            } else if (contentResponse.results || contentResponse.blocks || Array.isArray(contentResponse)) {
+                pageContent = contentResponse;
+            }
+        }
 
         renderOrderDetail(order, pageContent);
         openDetailModal();
@@ -497,11 +509,29 @@ function renderBlock(block, depth = 0) {
  * @returns {string} HTML string
  */
 function renderPageContent(pageContent) {
-    if (!pageContent || !pageContent.blocks || pageContent.blocks.length === 0) {
+    if (!pageContent) {
         return '<div class="page-content-empty">No hay contenido adicional en esta página.</div>';
     }
 
-    return pageContent.blocks.map(block => renderBlock(block, 0)).filter(html => html).join('');
+    // Handle different API response formats:
+    // - Mock data format: { blocks: [...] }
+    // - Notion API format: { results: [...] }
+    // - Direct array format: [...]
+    let blocks = null;
+
+    if (Array.isArray(pageContent)) {
+        blocks = pageContent;
+    } else if (pageContent.blocks && Array.isArray(pageContent.blocks)) {
+        blocks = pageContent.blocks;
+    } else if (pageContent.results && Array.isArray(pageContent.results)) {
+        blocks = pageContent.results;
+    }
+
+    if (!blocks || blocks.length === 0) {
+        return '<div class="page-content-empty">No hay contenido adicional en esta página.</div>';
+    }
+
+    return blocks.map(block => renderBlock(block, 0)).filter(html => html).join('');
 }
 
 /**


### PR DESCRIPTION
The previous fix only handled the block format transformation but not the different API response structures. The Notion API returns blocks in a 'results' array, not 'blocks'.

Changes:
- Handle multiple API response formats in openOrderDetail:
  - Standard format: { success: true, data: {...} }
  - Direct data format: { blocks/results: [...] }
  - Direct array format: [...]
- Update renderPageContent to check for both 'blocks' and 'results' arrays, as well as direct array input

Fixes #11