### PR TITLE
Add proveedores (providers) to joyeros list

### DIFF
--- a/js/components/edit-modal.js
+++ b/js/components/edit-modal.js
@@ -40,10 +40,17 @@ const EditModal = {
             `<option value="${s.id}" ${order.estado === s.name ? 'selected' : ''}>${s.name}</option>`
         ).join('');
 
-        // Build joyero options
-        const joyeroOptions = CONFIG.JOYEROS.map(j =>
+        // Build joyero options with grouped sections (Joyeros and Proveedores)
+        const joyerosOptions = CONFIG.getJoyerosOnly().map(j =>
             `<option value="${j.name}" ${order.joyero === j.name ? 'selected' : ''}>${j.name}</option>`
         ).join('');
+        const proveedoresOptions = CONFIG.getProveedoresOnly().map(j =>
+            `<option value="${j.name}" ${order.joyero === j.name ? 'selected' : ''}>${j.name}</option>`
+        ).join('');
+        const joyeroOptions = `
+            <optgroup label="Joyeros">${joyerosOptions}</optgroup>
+            <optgroup label="Proveedores">${proveedoresOptions}</optgroup>
+        `;
 
         // Build tipo pedido options
         const tipoOptions = CONFIG.TIPOS_PEDIDO.map(t =>

--- a/js/config.js
+++ b/js/config.js
@@ -42,18 +42,44 @@ const CONFIG = {
     },
 
     // ==========================================================================
-    // Joyeros (Jewelry Makers)
+    // Joyeros (Jewelry Makers) and Proveedores (Providers)
     // ==========================================================================
 
-    // List of jewelry makers that can be assigned to orders
+    // List of jewelry makers and providers that can be assigned to orders
+    // type: 'joyero' = jewelry maker (gold movements tracked)
+    // type: 'proveedor' = external provider (no gold movement tracking)
     JOYEROS: [
-        { id: 'carlos', name: 'Carlos' },
-        { id: 'victor', name: 'Victor' },
-        { id: 'israel', name: 'Israel' },
-        { id: 'marcos', name: 'Marcos' },
-        { id: 'salvador', name: 'Salvador' },
-        { id: 'juan', name: 'Juan' },
+        { id: 'carlos', name: 'Carlos', type: 'joyero' },
+        { id: 'victor', name: 'Victor', type: 'joyero' },
+        { id: 'israel', name: 'Israel', type: 'joyero' },
+        { id: 'marcos', name: 'Marcos', type: 'joyero' },
+        { id: 'salvador', name: 'Salvador', type: 'joyero' },
+        { id: 'juan', name: 'Juan', type: 'joyero' },
+        { id: 'a2', name: 'A2', type: 'proveedor' },
+        { id: 'a30', name: 'A30', type: 'proveedor' },
+        { id: 'a20', name: 'A20', type: 'proveedor' },
+        { id: 'a99', name: 'A99', type: 'proveedor' },
+        { id: 'a19', name: 'A19', type: 'proveedor' },
+        { id: 'a14', name: 'A14', type: 'proveedor' },
+        { id: 'a10', name: 'A10', type: 'proveedor' },
+        { id: 'a6', name: 'A6', type: 'proveedor' },
     ],
+
+    // Helper to get only joyeros (no providers)
+    getJoyerosOnly() {
+        return this.JOYEROS.filter(j => j.type === 'joyero');
+    },
+
+    // Helper to get only providers
+    getProveedoresOnly() {
+        return this.JOYEROS.filter(j => j.type === 'proveedor');
+    },
+
+    // Helper to check if a name is a provider
+    isProveedor(name) {
+        const entry = this.JOYEROS.find(j => j.name === name);
+        return entry ? entry.type === 'proveedor' : false;
+    },
 
     // ==========================================================================
     // Order Types

--- a/js/pages/joyeros.js
+++ b/js/pages/joyeros.js
@@ -42,11 +42,12 @@ async function initPage() {
 
 /**
  * Initialize joyero dropdown options
+ * Only includes joyeros (not providers) since providers don't track gold
  */
 function initJoyeroDropdown() {
     const select = document.getElementById('mov-joyero');
     if (select) {
-        CONFIG.JOYEROS.forEach(j => {
+        CONFIG.getJoyerosOnly().forEach(j => {
             const option = document.createElement('option');
             option.value = j.name;
             option.textContent = j.name;
@@ -104,13 +105,14 @@ async function loadMovements() {
 
 /**
  * Render joyero balance cards
+ * Only shows joyeros (not providers) since providers don't track gold
  */
 function renderJoyeroCards() {
     const container = document.getElementById('joyero-cards');
     if (!container) return;
 
-    // Sort joyeros by balance descending
-    const sortedJoyeros = CONFIG.JOYEROS.map(j => ({
+    // Sort joyeros by balance descending (exclude providers)
+    const sortedJoyeros = CONFIG.getJoyerosOnly().map(j => ({
         name: j.name,
         ...balances[j.name] || { balance: 0, total_entrada: 0, total_salida: 0 }
     })).sort((a, b) => b.balance - a.balance);

--- a/js/pages/nuevo-pedido.js
+++ b/js/pages/nuevo-pedido.js
@@ -244,14 +244,30 @@ window.printOrder = function() {
             tipoSelect.appendChild(option);
         });
 
-        // Populate joyeros dropdown
+        // Populate joyeros dropdown with grouped sections
         const joyeroSelect = document.getElementById('joyero');
-        CONFIG.JOYEROS.forEach(joyero => {
+
+        // Add Joyeros group
+        const joyerosGroup = document.createElement('optgroup');
+        joyerosGroup.label = 'Joyeros';
+        CONFIG.getJoyerosOnly().forEach(joyero => {
             const option = document.createElement('option');
             option.value = joyero.name;
             option.textContent = joyero.name;
-            joyeroSelect.appendChild(option);
+            joyerosGroup.appendChild(option);
         });
+        joyeroSelect.appendChild(joyerosGroup);
+
+        // Add Proveedores group
+        const proveedoresGroup = document.createElement('optgroup');
+        proveedoresGroup.label = 'Proveedores';
+        CONFIG.getProveedoresOnly().forEach(proveedor => {
+            const option = document.createElement('option');
+            option.value = proveedor.name;
+            option.textContent = proveedor.name;
+            proveedoresGroup.appendChild(option);
+        });
+        joyeroSelect.appendChild(proveedoresGroup);
 
         // Populate gemas origen dropdown
         const gemasOrigenSelect = document.getElementById('gemas_origen');

--- a/js/pages/pedidos.js
+++ b/js/pages/pedidos.js
@@ -54,15 +54,30 @@ function initFilters() {
         });
     }
 
-    // Joyero filter
+    // Joyero filter (with grouped Joyeros and Proveedores)
     const joyeroSelect = document.getElementById('filter-joyero');
     if (joyeroSelect && CONFIG.JOYEROS.length > 0) {
-        CONFIG.JOYEROS.forEach(joyero => {
+        // Add Joyeros group
+        const joyerosGroup = document.createElement('optgroup');
+        joyerosGroup.label = 'Joyeros';
+        CONFIG.getJoyerosOnly().forEach(joyero => {
             const option = document.createElement('option');
             option.value = joyero.name;
             option.textContent = joyero.name;
-            joyeroSelect.appendChild(option);
+            joyerosGroup.appendChild(option);
         });
+        joyeroSelect.appendChild(joyerosGroup);
+
+        // Add Proveedores group
+        const proveedoresGroup = document.createElement('optgroup');
+        proveedoresGroup.label = 'Proveedores';
+        CONFIG.getProveedoresOnly().forEach(proveedor => {
+            const option = document.createElement('option');
+            option.value = proveedor.name;
+            option.textContent = proveedor.name;
+            proveedoresGroup.appendChild(option);
+        });
+        joyeroSelect.appendChild(proveedoresGroup);
     }
 
     // Vendedora filter
@@ -290,11 +305,14 @@ window.handleSaveOrder = async function() {
     }
 
     // Check if we need to auto-deduct gold (status changed to "En Producción")
+    // Note: Providers (proveedores) do not track gold movements
     const statusChangedToProduccion = currentOrder.estado !== 'En Producción' && formData.estado === 'En Producción';
+    const isProvider = CONFIG.isProveedor(formData.joyero);
     const shouldDeductGold = statusChangedToProduccion &&
         formData.oro_gramos > 0 &&
         formData.joyero &&
-        formData.oro_con_joyero === true;
+        formData.oro_con_joyero === true &&
+        !isProvider;
 
     // Debug logging
     console.log('=== Gold Deduction Debug ===');
@@ -304,6 +322,7 @@ window.handleSaveOrder = async function() {
     console.log('formData.oro_gramos:', formData.oro_gramos);
     console.log('formData.joyero:', formData.joyero);
     console.log('formData.oro_con_joyero:', formData.oro_con_joyero);
+    console.log('isProvider:', isProvider);
     console.log('shouldDeductGold:', shouldDeductGold);
 
     // Show loading state


### PR DESCRIPTION
- Add type property to distinguish joyeros from proveedores
- Add 8 providers: A2, A30, A20, A99, A19, A14, A10, A6
- Skip gold movement tracking for providers when orders go to production
- Group joyeros and proveedores in dropdowns with optgroup labels
- Exclude providers from joyeros balance tracking page