### PR TITLE
Fix Lambda ESM module syntax in prisma_Pagos

### DIFF
--- a/lambda/prisma_Pagos/index.mjs
+++ b/lambda/prisma_Pagos/index.mjs
@@ -31,7 +31,7 @@
  * - creado_por: Text
  */
 
-const { Client } = require('@notionhq/client');
+import { Client } from '@notionhq/client';
 
 // Initialize Notion client
 const notion = new Client({ auth: process.env.NOTION_TOKEN });
@@ -48,7 +48,7 @@ const headers = {
 /**
  * Main handler
  */
-exports.handler = async (event) => {
+export const handler = async (event) => {
     console.log('Event:', JSON.stringify(event));
 
     // Handle CORS preflight


### PR DESCRIPTION
Convert CommonJS require/exports to ES module import/export syntax to resolve "require is not defined in ES module scope" error that crashes the Lambda when users add a new payment.

Fixes #19