### PR TITLE
Fix 404 error by supporting HTTP API v2 event format in prisma_Pagos

### DIFF
--- a/lambda/prisma_Pagos/index.mjs
+++ b/lambda/prisma_Pagos/index.mjs
@@ -51,14 +51,17 @@ const headers = {
 export const handler = async (event) => {
     console.log('Event:', JSON.stringify(event));
 
+    // Support both REST API (v1) and HTTP API (v2) event formats
+    const method = event.httpMethod || event.requestContext?.http?.method;
+
     // Handle CORS preflight
-    if (event.httpMethod === 'OPTIONS') {
+    if (method === 'OPTIONS') {
         return { statusCode: 200, headers, body: '' };
     }
 
     try {
-        const method = event.httpMethod;
-        const path = event.path || event.resource || '';
+        // HTTP API v2 uses rawPath, REST API v1 uses path or resource
+        const path = event.rawPath || event.path || event.resource || '';
         const pathParams = event.pathParameters || {};
 
         // Route handling


### PR DESCRIPTION
The Lambda was returning 404 because it wasn't extracting the path and method correctly when invoked via API Gateway HTTP API (v2). HTTP API v2 uses different event properties:
- event.rawPath instead of event.path
- event.requestContext.http.method instead of event.httpMethod

Now the handler checks both formats to support REST API (v1) and HTTP API (v2).

https://claude.ai/code/session_01BsYAHduYByQiteWbn55dgr