### PR TITLE
Show order number in movement type badge for Salida Pedido

### DIFF
--- a/js/pages/joyeros.js
+++ b/js/pages/joyeros.js
@@ -240,7 +240,7 @@ function renderMovementsTable() {
                     <div class="movement-time">${timeStr}</div>
                 </td>
                 <td><strong>${m.joyero}</strong></td>
-                <td><span class="movement-type ${tipoClass}">${m.tipo_movimiento}</span></td>
+                <td><span class="movement-type ${tipoClass}">${m.tipo_movimiento}${(m.tipo_movimiento === 'Salida Pedido' && m.numero_orden) ? ` (${m.numero_orden})` : ''}</span></td>
                 <td class="text-right"><span class="movement-gramos ${tipoClass}">${gramosPrefix}${m.gramos.toFixed(1)}g</span></td>
                 <td class="movement-desc">${m.descripcion || '-'}</td>
                 <td>${m.numero_orden ? `<a href="pedidos.html" class="order-link">${m.numero_orden}</a>` : '-'}</td>


### PR DESCRIPTION
When a gold movement is of type "Salida Pedido" and has an associated
order number (numero_orden), display it in the type badge as
"Salida Pedido (1234)" for quick reference.

Closes #23

https://claude.ai/code/session_013qLJ1ydsp2oLjWNjcwS9Vi