### PR TITLE
Add payment method breakdown (desglose) for P&L classification

### DIFF
--- a/css/pagos.css
+++ b/css/pagos.css
@@ -994,6 +994,285 @@
 }
 
 /* ==========================================================================
+   Desglose (Breakdown) Styles
+   ========================================================================== */
+
+/* Badge on pago cards */
+.desglose-badge {
+    display: inline-block;
+    padding: 3px 8px;
+    font-size: 11px;
+    font-weight: 600;
+    border-radius: 10px;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+}
+
+.desglose-badge:hover {
+    transform: scale(1.05);
+}
+
+.desglose-badge-pending {
+    background: #fef3c7;
+    color: #92400e;
+    border: 1px solid #fbbf2440;
+}
+
+.desglose-badge-partial {
+    background: #fef3c7;
+    color: #92400e;
+    border: 1px solid #f59e0b40;
+}
+
+.desglose-badge-complete {
+    background: #dcfce7;
+    color: #166534;
+    border: 1px solid #22c55e40;
+}
+
+/* Section inside edit modal */
+.desglose-section {
+    background: #f9fafb;
+    border-radius: 8px;
+    padding: 16px;
+    border: 1px dashed var(--border);
+}
+
+.desglose-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.desglose-section-title {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--text-primary);
+}
+
+.desglose-section-desc {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+}
+
+.desglose-open-btn {
+    width: 100%;
+}
+
+/* Desglose Modal */
+#desglose-modal .modal {
+    max-width: 700px;
+}
+
+#desglose-modal .modal-body {
+    max-height: 70vh;
+}
+
+.desglose-summary-header {
+    background: #f3f4f6;
+    padding: 12px 16px;
+    border-radius: 8px;
+    margin-bottom: 16px;
+}
+
+.desglose-pago-total {
+    font-size: 14px;
+    color: var(--text-secondary);
+}
+
+.desglose-pago-total strong {
+    font-size: 18px;
+    color: var(--text-primary);
+}
+
+/* Line items container */
+.desglose-items-container {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.desglose-empty {
+    text-align: center;
+    padding: 32px 16px;
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+/* Individual line item */
+.desglose-item {
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.desglose-item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.desglose-item-number {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.desglose-item-remove {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-muted);
+    padding: 4px;
+    border-radius: 4px;
+    transition: all 0.2s;
+}
+
+.desglose-item-remove:hover {
+    color: #dc2626;
+    background: #fef2f2;
+}
+
+.desglose-item-row {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.desglose-item-row:last-child {
+    margin-bottom: 0;
+}
+
+.desglose-item-field {
+    flex: 1;
+}
+
+.desglose-item-field-desc {
+    flex: 2;
+}
+
+.desglose-item-field-monto {
+    flex: 1;
+}
+
+.desglose-field-label {
+    display: block;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    margin-bottom: 4px;
+}
+
+.desglose-field-label input[type="checkbox"] {
+    margin-right: 4px;
+    vertical-align: middle;
+}
+
+/* Tipo toggle (personal / negocio) */
+.desglose-tipo-toggle {
+    display: flex;
+    gap: 4px;
+    background: var(--bg-tertiary);
+    border-radius: 6px;
+    padding: 2px;
+}
+
+.desglose-tipo-btn {
+    flex: 1;
+    padding: 6px 12px;
+    border: none;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    background: transparent;
+    color: var(--text-muted);
+    transition: all 0.2s;
+}
+
+.desglose-tipo-btn.active.desglose-tipo-negocio {
+    background: #dcfce7;
+    color: #166534;
+}
+
+.desglose-tipo-btn.active.desglose-tipo-personal {
+    background: #fef3c7;
+    color: #92400e;
+}
+
+.desglose-tipo-btn:hover:not(.active) {
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+}
+
+/* Category selects inside desglose */
+.desglose-cat-select {
+    font-size: 13px;
+}
+
+/* Add button */
+.desglose-add-btn {
+    width: 100%;
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+
+/* Totals */
+.desglose-totals {
+    background: #f9fafb;
+    border-radius: 8px;
+    padding: 12px 16px;
+    border: 1px solid var(--border);
+}
+
+.desglose-totals-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 6px 0;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.desglose-totals-row:last-child {
+    border-top: 1px solid var(--border);
+    padding-top: 10px;
+    margin-top: 4px;
+    font-weight: 600;
+}
+
+.desglose-totals-negocio {
+    color: #166534;
+}
+
+.desglose-totals-personal {
+    color: #92400e;
+}
+
+.desglose-balance-ok {
+    color: #166534 !important;
+}
+
+.desglose-balance-pending {
+    color: #b45309 !important;
+}
+
+.desglose-balance-over {
+    color: #dc2626 !important;
+}
+
+/* ==========================================================================
    Mobile Responsive
    ========================================================================== */
 
@@ -1084,5 +1363,20 @@
 
     .fx-options {
         flex-wrap: wrap;
+    }
+
+    /* Desglose responsive */
+    .desglose-item-row {
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .desglose-item-field-desc,
+    .desglose-item-field-monto {
+        flex: none;
+    }
+
+    #desglose-modal .modal {
+        max-width: 100%;
     }
 }

--- a/js/api.js
+++ b/js/api.js
@@ -373,6 +373,37 @@ const API = {
     },
 
     // ==========================================================================
+    // Desglose (Breakdown) API
+    // ==========================================================================
+
+    /**
+     * Get desglose (breakdown) for a pago
+     * @param {string} pagoId - Pago ID
+     * @returns {Promise<Array>} Array of desglose line items
+     */
+    async getDesglose(pagoId) {
+        return this.request(`/pagos/${pagoId}/desglose`, {
+            method: 'GET'
+        });
+    },
+
+    /**
+     * Update desglose (breakdown) for a pago
+     * @param {string} pagoId - Pago ID
+     * @param {Array} desglose - Array of breakdown line items
+     * @returns {Promise<Object>} Updated desglose
+     */
+    async updateDesglose(pagoId, desglose) {
+        return this.request(`/pagos/${pagoId}/desglose`, {
+            method: 'PUT',
+            body: JSON.stringify({
+                desglose: desglose,
+                user: Auth.getUserName()
+            })
+        });
+    },
+
+    // ==========================================================================
     // FX Rate API
     // ==========================================================================
 

--- a/js/components/desglose-modal.js
+++ b/js/components/desglose-modal.js
@@ -1,0 +1,419 @@
+/**
+ * Desglose (Breakdown) Modal Component
+ *
+ * Allows the business owner to break down a "Método de Pago" pago
+ * into individual line items classified as personal or negocio.
+ */
+
+const DesgloseModal = {
+    currentPagoId: null,
+    currentPagoMonto: 0,
+    currentPagoMoneda: 'MXN',
+    lineItems: [],
+    isLoading: false,
+
+    /**
+     * Open the desglose modal for a given pago
+     * @param {Object} pago - Pago data
+     */
+    async open(pago) {
+        this.currentPagoId = pago.id;
+        this.currentPagoMonto = pago.monto || 0;
+        this.currentPagoMoneda = pago.moneda || 'MXN';
+
+        // If desglose data already loaded on the pago object, use it
+        if (pago.desglose && Array.isArray(pago.desglose)) {
+            this.lineItems = JSON.parse(JSON.stringify(pago.desglose));
+        } else {
+            this.lineItems = [];
+        }
+
+        this.render();
+        document.getElementById('desglose-modal').classList.add('active');
+        document.body.style.overflow = 'hidden';
+
+        // If no cached desglose, try fetching from API
+        if (!pago.desglose) {
+            await this.loadFromAPI(pago.id);
+        }
+    },
+
+    /**
+     * Load desglose from API
+     * @param {string} pagoId - Pago ID
+     */
+    async loadFromAPI(pagoId) {
+        try {
+            this.isLoading = true;
+            this.renderLoadingState();
+            const response = await API.getDesglose(pagoId);
+            if (response.success && Array.isArray(response.data)) {
+                this.lineItems = response.data;
+            }
+        } catch (error) {
+            console.warn('Could not load desglose:', error);
+        } finally {
+            this.isLoading = false;
+            this.render();
+        }
+    },
+
+    /**
+     * Close the modal
+     */
+    close() {
+        this.currentPagoId = null;
+        this.lineItems = [];
+        document.getElementById('desglose-modal').classList.remove('active');
+        document.body.style.overflow = '';
+    },
+
+    /**
+     * Add a new empty line item
+     */
+    addLineItem() {
+        this.lineItems.push({
+            descripcion: '',
+            monto: 0,
+            tipo: 'negocio',
+            categoria: '',
+            subcategoria: '',
+            es_fiscal: false
+        });
+        this.render();
+
+        // Focus the new description input
+        setTimeout(() => {
+            const inputs = document.querySelectorAll('.desglose-item-desc');
+            if (inputs.length > 0) {
+                inputs[inputs.length - 1].focus();
+            }
+        }, 50);
+    },
+
+    /**
+     * Remove a line item by index
+     * @param {number} index - Index to remove
+     */
+    removeLineItem(index) {
+        this.lineItems.splice(index, 1);
+        this.render();
+    },
+
+    /**
+     * Update a line item field
+     * @param {number} index - Line item index
+     * @param {string} field - Field name
+     * @param {*} value - New value
+     */
+    updateLineItem(index, field, value) {
+        if (!this.lineItems[index]) return;
+        this.lineItems[index][field] = value;
+
+        // When tipo changes to personal, clear category fields
+        if (field === 'tipo' && value === 'personal') {
+            this.lineItems[index].categoria = '';
+            this.lineItems[index].subcategoria = '';
+        }
+
+        // When categoria changes, reset subcategoria
+        if (field === 'categoria') {
+            this.lineItems[index].subcategoria = '';
+        }
+
+        this.render();
+    },
+
+    /**
+     * Sync line item values from DOM inputs (for fields that don't trigger full re-render)
+     */
+    syncFromDOM() {
+        this.lineItems.forEach((item, i) => {
+            const descInput = document.getElementById(`desglose-desc-${i}`);
+            const montoInput = document.getElementById(`desglose-monto-${i}`);
+            if (descInput) item.descripcion = descInput.value;
+            if (montoInput) item.monto = parseFloat(montoInput.value) || 0;
+        });
+    },
+
+    /**
+     * Calculate totals
+     * @returns {Object} Totals object
+     */
+    getTotals() {
+        let totalDesglose = 0;
+        let totalPersonal = 0;
+        let totalNegocio = 0;
+
+        this.lineItems.forEach(item => {
+            const monto = parseFloat(item.monto) || 0;
+            totalDesglose += monto;
+            if (item.tipo === 'personal') {
+                totalPersonal += monto;
+            } else {
+                totalNegocio += monto;
+            }
+        });
+
+        return {
+            totalDesglose,
+            totalPersonal,
+            totalNegocio,
+            sinAsignar: this.currentPagoMonto - totalDesglose
+        };
+    },
+
+    /**
+     * Format currency amount
+     * @param {number} amount - Amount
+     * @returns {string} Formatted string
+     */
+    formatCurrency(amount) {
+        const formatted = new Intl.NumberFormat('es-MX', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+        }).format(Math.abs(amount));
+        const prefix = this.currentPagoMoneda === 'USD' ? 'USD $' : '$';
+        return `${amount < 0 ? '-' : ''}${prefix}${formatted}`;
+    },
+
+    /**
+     * Build category options HTML (excluding metodo_pago)
+     * @param {string} selected - Selected category key
+     * @returns {string} HTML options
+     */
+    buildCategoryOptions(selected) {
+        let html = '<option value="">-- Categoría --</option>';
+        for (const [key, cat] of Object.entries(CONFIG.PAGO_CATEGORIES)) {
+            if (key === 'metodo_pago') continue;
+            html += `<option value="${key}" ${selected === key ? 'selected' : ''}>${cat.name}</option>`;
+        }
+        return html;
+    },
+
+    /**
+     * Build subcategory options HTML
+     * @param {string} categoriaKey - Category key
+     * @param {string} selected - Selected subcategory
+     * @returns {string} HTML options
+     */
+    buildSubcategoryOptions(categoriaKey, selected) {
+        let html = '<option value="">-- Subcategoría --</option>';
+        const category = CONFIG.PAGO_CATEGORIES[categoriaKey];
+        if (category && category.subcategories) {
+            category.subcategories.forEach(sub => {
+                html += `<option value="${sub}" ${selected === sub ? 'selected' : ''}>${sub}</option>`;
+            });
+        }
+        return html;
+    },
+
+    /**
+     * Show loading state
+     */
+    renderLoadingState() {
+        const body = document.getElementById('desglose-modal-body');
+        if (body) {
+            body.innerHTML = '<div style="text-align: center; padding: 40px; color: var(--text-muted);">Cargando desglose...</div>';
+        }
+    },
+
+    /**
+     * Render the modal content
+     */
+    render() {
+        const totals = this.getTotals();
+        const balanceOk = Math.abs(totals.sinAsignar) < 0.01;
+        const hasItems = this.lineItems.length > 0;
+
+        // Build line items HTML
+        let itemsHtml = '';
+        this.lineItems.forEach((item, i) => {
+            const isPersonal = item.tipo === 'personal';
+            const tipoBadgeClass = isPersonal ? 'desglose-tipo-personal' : 'desglose-tipo-negocio';
+            const tipoBadgeText = isPersonal ? 'Personal' : 'Negocio';
+
+            itemsHtml += `
+                <div class="desglose-item" data-index="${i}">
+                    <div class="desglose-item-header">
+                        <span class="desglose-item-number">#${i + 1}</span>
+                        <button class="desglose-item-remove" onclick="DesgloseModal.syncFromDOM(); DesgloseModal.removeLineItem(${i})" title="Eliminar">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                        </button>
+                    </div>
+                    <div class="desglose-item-row">
+                        <div class="desglose-item-field desglose-item-field-desc">
+                            <label class="desglose-field-label">Descripción</label>
+                            <input type="text" class="form-input desglose-item-desc" id="desglose-desc-${i}" value="${this.escapeAttr(item.descripcion)}" placeholder="Ej: Compra de piedras">
+                        </div>
+                        <div class="desglose-item-field desglose-item-field-monto">
+                            <label class="desglose-field-label">Monto</label>
+                            <input type="number" class="form-input desglose-item-monto" id="desglose-monto-${i}" value="${item.monto || ''}" step="0.01" min="0" placeholder="0.00" onchange="DesgloseModal.syncFromDOM(); DesgloseModal.render();">
+                        </div>
+                    </div>
+                    <div class="desglose-item-row">
+                        <div class="desglose-item-field">
+                            <label class="desglose-field-label">Tipo</label>
+                            <div class="desglose-tipo-toggle">
+                                <button class="desglose-tipo-btn ${!isPersonal ? 'active desglose-tipo-negocio' : ''}" onclick="DesgloseModal.syncFromDOM(); DesgloseModal.updateLineItem(${i}, 'tipo', 'negocio')">Negocio</button>
+                                <button class="desglose-tipo-btn ${isPersonal ? 'active desglose-tipo-personal' : ''}" onclick="DesgloseModal.syncFromDOM(); DesgloseModal.updateLineItem(${i}, 'tipo', 'personal')">Personal</button>
+                            </div>
+                        </div>
+                        <div class="desglose-item-field">
+                            <label class="desglose-field-label">
+                                <input type="checkbox" ${item.es_fiscal ? 'checked' : ''} onchange="DesgloseModal.syncFromDOM(); DesgloseModal.updateLineItem(${i}, 'es_fiscal', this.checked)">
+                                Fiscal
+                            </label>
+                        </div>
+                    </div>
+                    ${!isPersonal ? `
+                    <div class="desglose-item-row">
+                        <div class="desglose-item-field">
+                            <label class="desglose-field-label">Categoría P&L</label>
+                            <select class="form-select desglose-cat-select" onchange="DesgloseModal.syncFromDOM(); DesgloseModal.updateLineItem(${i}, 'categoria', this.value)">
+                                ${this.buildCategoryOptions(item.categoria)}
+                            </select>
+                        </div>
+                        <div class="desglose-item-field">
+                            <label class="desglose-field-label">Subcategoría</label>
+                            <select class="form-select" onchange="DesgloseModal.syncFromDOM(); DesgloseModal.updateLineItem(${i}, 'subcategoria', this.value)">
+                                ${this.buildSubcategoryOptions(item.categoria, item.subcategoria)}
+                            </select>
+                        </div>
+                    </div>
+                    ` : ''}
+                </div>
+            `;
+        });
+
+        // Totals summary
+        const sinAsignarClass = balanceOk ? 'desglose-balance-ok' : (totals.sinAsignar < 0 ? 'desglose-balance-over' : 'desglose-balance-pending');
+        const sinAsignarLabel = balanceOk ? 'Cuadra' : (totals.sinAsignar < 0 ? 'Excedente' : 'Sin asignar');
+
+        const html = `
+            <div class="desglose-summary-header">
+                <div class="desglose-pago-total">
+                    Total del pago: <strong>${this.formatCurrency(this.currentPagoMonto)}</strong>
+                </div>
+            </div>
+
+            <div class="desglose-items-container">
+                ${hasItems ? itemsHtml : '<div class="desglose-empty">No hay partidas. Agrega una para comenzar el desglose.</div>'}
+            </div>
+
+            <button class="btn btn-secondary desglose-add-btn" onclick="DesgloseModal.syncFromDOM(); DesgloseModal.addLineItem()">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+                Agregar partida
+            </button>
+
+            ${hasItems ? `
+            <div class="desglose-totals">
+                <div class="desglose-totals-row">
+                    <span>Total desglose:</span>
+                    <span>${this.formatCurrency(totals.totalDesglose)}</span>
+                </div>
+                <div class="desglose-totals-row desglose-totals-negocio">
+                    <span>Negocio:</span>
+                    <span>${this.formatCurrency(totals.totalNegocio)}</span>
+                </div>
+                <div class="desglose-totals-row desglose-totals-personal">
+                    <span>Personal:</span>
+                    <span>${this.formatCurrency(totals.totalPersonal)}</span>
+                </div>
+                <div class="desglose-totals-row desglose-totals-balance ${sinAsignarClass}">
+                    <span>${sinAsignarLabel}:</span>
+                    <span>${balanceOk ? '0.00' : this.formatCurrency(Math.abs(totals.sinAsignar))}</span>
+                </div>
+            </div>
+            ` : ''}
+        `;
+
+        document.getElementById('desglose-modal-body').innerHTML = html;
+    },
+
+    /**
+     * Save desglose to API
+     */
+    async save() {
+        this.syncFromDOM();
+
+        // Validate
+        const errors = [];
+        this.lineItems.forEach((item, i) => {
+            if (!item.descripcion || !item.descripcion.trim()) {
+                errors.push(`Partida #${i + 1}: descripción requerida`);
+            }
+            if (!item.monto || item.monto <= 0) {
+                errors.push(`Partida #${i + 1}: monto debe ser mayor a 0`);
+            }
+            if (item.tipo === 'negocio' && !item.categoria) {
+                errors.push(`Partida #${i + 1}: categoría P&L requerida para partidas de negocio`);
+            }
+        });
+
+        if (errors.length > 0) {
+            Utils.showToast(errors[0], 'error');
+            return;
+        }
+
+        const saveBtn = document.getElementById('desglose-modal-save-btn');
+        const originalText = saveBtn.textContent;
+        saveBtn.textContent = 'Guardando...';
+        saveBtn.disabled = true;
+
+        try {
+            const response = await API.updateDesglose(this.currentPagoId, this.lineItems);
+
+            if (response.success) {
+                Utils.showToast('Desglose guardado', 'success');
+
+                // Update local pago data
+                const pago = allPagos.find(p => p.id === this.currentPagoId);
+                if (pago) {
+                    pago.desglose = JSON.parse(JSON.stringify(this.lineItems));
+                }
+
+                this.close();
+
+                // Re-render views
+                if (typeof applyPagoFilters === 'function') {
+                    applyPagoFilters();
+                }
+            } else {
+                Utils.showToast(response.error || 'Error al guardar desglose', 'error');
+            }
+        } catch (error) {
+            console.error('Error saving desglose:', error);
+            Utils.showToast('Error de conexión', 'error');
+        } finally {
+            saveBtn.textContent = originalText;
+            saveBtn.disabled = false;
+        }
+    },
+
+    /**
+     * Escape HTML attribute
+     * @param {string} str - String to escape
+     * @returns {string} Escaped string
+     */
+    escapeAttr(str) {
+        if (!str) return '';
+        return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+};
+
+// Global function for onclick
+function openDesgloseModal(pagoId) {
+    const pago = allPagos.find(p => p.id === pagoId);
+    if (pago) {
+        DesgloseModal.open(pago);
+    }
+}
+
+function closeDesgloseModal() {
+    DesgloseModal.close();
+}
+
+function saveDesglose() {
+    DesgloseModal.save();
+}

--- a/js/components/pago-card.js
+++ b/js/components/pago-card.js
@@ -74,6 +74,38 @@ const PagoCard = {
     },
 
     /**
+     * Check if a pago is a payment method type that needs breakdown
+     * @param {Object} pago - Pago data
+     * @returns {boolean}
+     */
+    isMetodoPago(pago) {
+        return pago.categoria === 'metodo_pago';
+    },
+
+    /**
+     * Get desglose status info for a metodo_pago pago
+     * @param {Object} pago - Pago data
+     * @returns {Object} Status with label, class, count
+     */
+    getDesgloseStatus(pago) {
+        if (!this.isMetodoPago(pago)) return null;
+
+        const desglose = pago.desglose;
+        if (!desglose || !Array.isArray(desglose) || desglose.length === 0) {
+            return { label: 'Desglose pendiente', cssClass: 'desglose-badge-pending', count: 0 };
+        }
+
+        const total = desglose.reduce((sum, item) => sum + (parseFloat(item.monto) || 0), 0);
+        const balanced = Math.abs(total - (pago.monto || 0)) < 0.01;
+
+        if (balanced) {
+            return { label: `Desglose: ${desglose.length} partida${desglose.length !== 1 ? 's' : ''}`, cssClass: 'desglose-badge-complete', count: desglose.length };
+        }
+
+        return { label: `Desglose: incompleto`, cssClass: 'desglose-badge-partial', count: desglose.length };
+    },
+
+    /**
      * Render a full pago card for list view
      * @param {Object} pago - Pago data
      * @returns {string} HTML string
@@ -89,6 +121,7 @@ const PagoCard = {
         const finalDateClass = showDateWarning ? dateClass : '';
 
         const categoryName = this.getCategoryName(pago.categoria);
+        const desgloseStatus = this.getDesgloseStatus(pago);
 
         return `
             <div class="pago-card" data-pago-id="${pago.id}" onclick="openPagoEditModal('${pago.id}')">
@@ -122,6 +155,11 @@ const PagoCard = {
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="4" rx="2" ry="2"/><line x1="16" x2="16" y1="2" y2="6"/><line x1="8" x2="8" y1="2" y2="6"/><line x1="3" x2="21" y1="10" y2="10"/></svg>
                         ${Utils.formatDate(pago.fecha_vencimiento)}
                     </div>
+                    ${desgloseStatus ? `
+                    <span class="desglose-badge ${desgloseStatus.cssClass}" onclick="event.stopPropagation(); openDesgloseModal('${pago.id}')" title="Ver desglose">
+                        ${desgloseStatus.label}
+                    </span>
+                    ` : ''}
                 </div>
             </div>
         `;
@@ -142,12 +180,18 @@ const PagoCard = {
         const finalDateClass = showDateWarning ? dateClass : '';
 
         const categoryName = this.getCategoryName(pago.categoria);
+        const desgloseStatus = this.getDesgloseStatus(pago);
 
         return `
             <div class="kanban-card pago-kanban-card" data-pago-id="${pago.id}" onclick="openPagoEditModal('${pago.id}')">
                 <div class="kanban-card-amount">${this.formatPagoCurrency(pago.monto, pago.moneda)}</div>
                 <div class="kanban-card-category">${this.escapeHtml(Utils.truncate(categoryName, 20))}</div>
                 <div class="kanban-card-subcategory">${this.escapeHtml(Utils.truncate(pago.subcategoria || '', 25))}</div>
+                ${desgloseStatus ? `
+                <div class="desglose-badge ${desgloseStatus.cssClass}" onclick="event.stopPropagation(); openDesgloseModal('${pago.id}')" style="margin-bottom: 6px; font-size: 10px;">
+                    ${desgloseStatus.label}
+                </div>
+                ` : ''}
                 <div class="kanban-card-footer">
                     <span class="kanban-card-fiscal">${pago.es_fiscal ? '📄' : ''}</span>
                     <span class="kanban-card-date ${finalDateClass}">${Utils.formatDate(pago.fecha_vencimiento)}</span>

--- a/js/components/pago-edit-modal.js
+++ b/js/components/pago-edit-modal.js
@@ -159,6 +159,25 @@ const PagoEditModal = {
                 <textarea class="form-textarea" id="edit-pago-descripcion">${this.escapeHtml(pago.descripcion || '')}</textarea>
             </div>
 
+            <!-- Desglose Button (only for metodo_pago) -->
+            ${pago.categoria === 'metodo_pago' ? `
+            <div class="divider"></div>
+            <div class="desglose-section">
+                <div class="desglose-section-header">
+                    <span class="desglose-section-title">Desglose de Partidas</span>
+                    ${(() => {
+                        const ds = PagoCard.getDesgloseStatus(pago);
+                        return ds ? `<span class="desglose-badge ${ds.cssClass}">${ds.label}</span>` : '';
+                    })()}
+                </div>
+                <p class="desglose-section-desc">Clasifica las partidas de este método de pago como personal o negocio para el P&L.</p>
+                <button class="btn btn-secondary btn-sm desglose-open-btn" onclick="event.preventDefault(); closePagoEditModal(); setTimeout(function(){ openDesgloseModal('${pago.id}'); }, 300);">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+                    Abrir Desglose
+                </button>
+            </div>
+            ` : ''}
+
             <!-- Notion Link -->
             ${pago.id ? `
             <div style="text-align: center; font-size: 11px; color: #9ca3af; margin-top: 16px;">

--- a/js/config.js
+++ b/js/config.js
@@ -231,6 +231,17 @@ const CONFIG = {
                 'Publicidad',
                 'Varios'
             ]
+        },
+        'metodo_pago': {
+            name: 'Método de Pago',
+            subcategories: [
+                'American Express',
+                'Visa',
+                'Mastercard',
+                'Transferencia',
+                'Efectivo',
+                'Otro'
+            ]
         }
     },
 

--- a/lambda/prisma_Pagos/index.mjs
+++ b/lambda/prisma_Pagos/index.mjs
@@ -73,6 +73,16 @@ export const handler = async (event) => {
             return await getPagos(event);
         }
 
+        if (path.match(/\/pagos\/[^/]+\/desglose$/) && method === 'GET') {
+            const id = path.split('/')[2] || pathParams.id || pathParams.proxy;
+            return await getDesglose(id);
+        }
+
+        if (path.match(/\/pagos\/[^/]+\/desglose$/) && method === 'PUT') {
+            const id = path.split('/')[2] || pathParams.id || pathParams.proxy;
+            return await updateDesglose(id, event);
+        }
+
         if (path.match(/\/pagos\/[^/]+$/) && method === 'GET') {
             return await getPago(pathParams.id || pathParams.proxy);
         }
@@ -321,12 +331,84 @@ async function updatePago(pagoId, event) {
 }
 
 /**
+ * Get desglose (breakdown) for a pago
+ */
+async function getDesglose(pagoId) {
+    console.log('Getting desglose for pago:', pagoId);
+
+    const response = await notion.pages.retrieve({ page_id: pagoId });
+    const desgloseRaw = getRichText(response.properties.desglose);
+
+    let desglose = [];
+    if (desgloseRaw) {
+        try {
+            desglose = JSON.parse(desgloseRaw);
+        } catch (e) {
+            console.warn('Failed to parse desglose JSON:', e);
+        }
+    }
+
+    return {
+        statusCode: 200,
+        headers,
+        body: JSON.stringify({ success: true, data: desglose })
+    };
+}
+
+/**
+ * Update desglose (breakdown) for a pago
+ */
+async function updateDesglose(pagoId, event) {
+    const body = JSON.parse(event.body);
+    const desglose = body.desglose || [];
+    const userName = body.user || 'Sistema';
+
+    console.log('Updating desglose for pago:', pagoId, 'items:', desglose.length);
+
+    const desgloseJson = JSON.stringify(desglose);
+
+    // Notion rich_text has a 2000 char limit per block; use multiple blocks if needed
+    const chunks = [];
+    for (let i = 0; i < desgloseJson.length; i += 2000) {
+        chunks.push({ text: { content: desgloseJson.slice(i, i + 2000) } });
+    }
+
+    await notion.pages.update({
+        page_id: pagoId,
+        properties: {
+            'desglose': { rich_text: chunks }
+        }
+    });
+
+    // Log the change
+    const changeLogEntry = `${formatTimestamp()} - Desglose actualizado (${desglose.length} partidas) por ${userName}`;
+    await notion.blocks.children.append({
+        block_id: pagoId,
+        children: [
+            {
+                object: 'block',
+                type: 'paragraph',
+                paragraph: {
+                    rich_text: [{ text: { content: changeLogEntry } }]
+                }
+            }
+        ]
+    });
+
+    return {
+        statusCode: 200,
+        headers,
+        body: JSON.stringify({ success: true, data: desglose })
+    };
+}
+
+/**
  * Transform Notion page to pago object
  */
 function transformPago(page) {
     const props = page.properties;
 
-    return {
+    const pago = {
         id: page.id,
         monto: getNumber(props.monto),
         moneda: getSelect(props.moneda) || 'MXN',
@@ -340,6 +422,20 @@ function transformPago(page) {
         created_at: page.created_time,
         updated_at: page.last_edited_time
     };
+
+    // Include desglose if present (for metodo_pago category)
+    const desgloseRaw = getRichText(props.desglose);
+    if (desgloseRaw) {
+        try {
+            pago.desglose = JSON.parse(desgloseRaw);
+        } catch (e) {
+            pago.desglose = null;
+        }
+    } else {
+        pago.desglose = null;
+    }
+
+    return pago;
 }
 
 // ==========================================================================

--- a/pagos.html
+++ b/pagos.html
@@ -173,6 +173,25 @@
         </div>
     </div>
 
+    <!-- Desglose Modal -->
+    <div class="modal-overlay" id="desglose-modal">
+        <div class="modal">
+            <div class="modal-header">
+                <h2 class="modal-title">Desglose de Partidas</h2>
+                <button class="modal-close" onclick="closeDesgloseModal()">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                </button>
+            </div>
+            <div class="modal-body" id="desglose-modal-body">
+                <!-- Desglose form rendered by JS -->
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-secondary" onclick="closeDesgloseModal()">Cancelar</button>
+                <button class="btn btn-primary" id="desglose-modal-save-btn" onclick="saveDesglose()">Guardar Desglose</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Loading Overlay -->
     <div class="loading-overlay" id="loading-overlay">
         <div class="loading-card">
@@ -189,6 +208,7 @@
     <script src="js/api.js"></script>
     <script src="js/components/pago-card.js"></script>
     <script src="js/components/pago-edit-modal.js"></script>
+    <script src="js/components/desglose-modal.js"></script>
     <script src="js/components/pago-calendar.js"></script>
     <script src="js/components/pago-graph.js"></script>
     <script src="js/pages/pagos.js"></script>


### PR DESCRIPTION
Adds a "Método de Pago" category (AmEx, Visa, etc.) so the assistant can log aggregated payment method expenses. The business owner can then open a breakdown modal in the password-protected pagos UI to classify each line item as personal or negocio with its own category and fiscal flag.

- New metodo_pago category in config with payment method subcategories
- Lambda endpoints GET/PUT /pagos/{id}/desglose for breakdown CRUD
- Desglose stored as JSON in a rich_text Notion property on the pago
- Desglose modal component with add/remove line items, tipo toggle, category selection, fiscal checkbox, and balance validation
- Pago cards show desglose status badge (pending/incomplete/complete)
- Edit modal shows "Abrir Desglose" button for metodo_pago pagos
- API client updated with getDesglose/updateDesglose methods
- Full CSS for desglose UI including mobile responsive styles

The assistant never sees breakdown data — it only creates the top-level pago. Breakdown detail is owner-only via the protected pagos dashboard.

https://claude.ai/code/session_01Ft61T46yo1FQ9bwLJ95woB