### PR TITLE
Add password gate to desglose modal

### DIFF
--- a/css/pagos.css
+++ b/css/pagos.css
@@ -1031,6 +1031,60 @@
     border: 1px solid #22c55e40;
 }
 
+/* Password gate inside desglose modal */
+.desglose-password-gate {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 32px 16px;
+    text-align: center;
+}
+
+.desglose-password-icon {
+    color: var(--text-muted);
+    margin-bottom: 16px;
+}
+
+.desglose-password-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+}
+
+.desglose-password-desc {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin-bottom: 20px;
+    max-width: 300px;
+}
+
+.desglose-password-input {
+    width: 100%;
+    max-width: 280px;
+    text-align: center;
+    font-size: 16px;
+    padding: 10px 16px;
+    margin-bottom: 8px;
+}
+
+.desglose-password-error {
+    font-size: 12px;
+    color: #dc2626;
+    margin-bottom: 12px;
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
+.desglose-password-error.visible {
+    opacity: 1;
+}
+
+.desglose-password-btn {
+    width: 100%;
+    max-width: 280px;
+}
+
 /* Section inside edit modal */
 .desglose-section {
     background: #f9fafb;

--- a/js/components/desglose-modal.js
+++ b/js/components/desglose-modal.js
@@ -11,6 +11,31 @@ const DesgloseModal = {
     currentPagoMoneda: 'MXN',
     lineItems: [],
     isLoading: false,
+    pendingPago: null,
+
+    /**
+     * Check if desglose session is authenticated
+     * @returns {boolean}
+     */
+    isAuthenticated() {
+        const session = sessionStorage.getItem('prisma_desglose_session');
+        if (!session) return false;
+        try {
+            return JSON.parse(session).authenticated === true;
+        } catch {
+            return false;
+        }
+    },
+
+    /**
+     * Store desglose session
+     */
+    storeSession() {
+        sessionStorage.setItem('prisma_desglose_session', JSON.stringify({
+            authenticated: true,
+            timestamp: Date.now()
+        }));
+    },
 
     /**
      * Open the desglose modal for a given pago
@@ -21,6 +46,79 @@ const DesgloseModal = {
         this.currentPagoMonto = pago.monto || 0;
         this.currentPagoMoneda = pago.moneda || 'MXN';
 
+        document.getElementById('desglose-modal').classList.add('active');
+        document.body.style.overflow = 'hidden';
+
+        // Check auth before showing content
+        if (!this.isAuthenticated()) {
+            this.pendingPago = pago;
+            this.renderPasswordGate();
+            return;
+        }
+
+        await this.loadContent(pago);
+    },
+
+    /**
+     * Render password gate inside the modal body
+     */
+    renderPasswordGate() {
+        const body = document.getElementById('desglose-modal-body');
+        body.innerHTML = `
+            <div class="desglose-password-gate">
+                <div class="desglose-password-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                </div>
+                <h3 class="desglose-password-title">Acceso al Desglose</h3>
+                <p class="desglose-password-desc">Ingresa la contraseña para ver y editar el desglose de partidas.</p>
+                <input type="password" class="form-input desglose-password-input" id="desglose-password-input" placeholder="Contraseña" onkeypress="if(event.key==='Enter') DesgloseModal.checkPassword()">
+                <p class="desglose-password-error" id="desglose-password-error">Contraseña incorrecta</p>
+                <button class="btn btn-primary desglose-password-btn" onclick="DesgloseModal.checkPassword()">Entrar</button>
+            </div>
+        `;
+
+        // Hide the footer buttons while on password gate
+        document.getElementById('desglose-modal-save-btn').style.display = 'none';
+
+        setTimeout(() => {
+            const input = document.getElementById('desglose-password-input');
+            if (input) input.focus();
+        }, 100);
+    },
+
+    /**
+     * Validate the entered password
+     */
+    async checkPassword() {
+        const input = document.getElementById('desglose-password-input');
+        const error = document.getElementById('desglose-password-error');
+
+        if (input.value === CONFIG.DESGLOSE_PASSWORD) {
+            error.classList.remove('visible');
+            input.classList.remove('error');
+            this.storeSession();
+
+            // Restore save button visibility
+            document.getElementById('desglose-modal-save-btn').style.display = '';
+
+            // Load the actual content
+            if (this.pendingPago) {
+                await this.loadContent(this.pendingPago);
+                this.pendingPago = null;
+            }
+        } else {
+            error.classList.add('visible');
+            input.classList.add('error', 'shake');
+            setTimeout(() => input.classList.remove('shake'), 300);
+            input.select();
+        }
+    },
+
+    /**
+     * Load desglose content after authentication
+     * @param {Object} pago - Pago data
+     */
+    async loadContent(pago) {
         // If desglose data already loaded on the pago object, use it
         if (pago.desglose && Array.isArray(pago.desglose)) {
             this.lineItems = JSON.parse(JSON.stringify(pago.desglose));
@@ -29,8 +127,6 @@ const DesgloseModal = {
         }
 
         this.render();
-        document.getElementById('desglose-modal').classList.add('active');
-        document.body.style.overflow = 'hidden';
 
         // If no cached desglose, try fetching from API
         if (!pago.desglose) {

--- a/js/config.js
+++ b/js/config.js
@@ -142,6 +142,9 @@ const CONFIG = {
     // Password for Pagos module (separate from dashboard)
     PAGOS_PASSWORD: 'pagostara',
 
+    // Password for Desglose (breakdown) access within Pagos
+    DESGLOSE_PASSWORD: 'desglosetara',
+
     // Pago Statuses with colors
     // Colors: orange (presupuestado), red (confirmado), green (pagado), black (cancelado)
     PAGO_ESTADOS: [


### PR DESCRIPTION
The desglose modal now requires a separate password (DESGLOSE_PASSWORD) before showing breakdown content. On first access per session, the owner sees a lock icon and password input inside the modal. After correct entry, the session is stored in sessionStorage (prisma_desglose_session) and subsequent opens skip the gate. The save button is hidden during the password prompt to avoid confusion.

This ensures the assistant (which only calls POST/GET/PUT /pagos) never sees breakdown data, and even users with pagos dashboard access need an additional password to view or edit the desglose.

https://claude.ai/code/session_01Ft61T46yo1FQ9bwLJ95woB